### PR TITLE
Oauth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ This Pipedrive API client is distributed under the MIT licence.
 - Make PR
 
 ## Options
-* `strictMode` - In strict mode `*_id` items in the responses are numeric IDs. Default is *false* in which case expanded
- objects are returned. Strict mode is recommended and is likely to be the default in the future.
 * `oauth` - whether the API token is to be used as OAuth bearer token instead of classic API key (default is *false*). 
 When setting `oauth` to true your application code must take care of fetching, storing and refershing the tokens.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This Pipedrive API client is distributed under the MIT licence.
 - Run tests
 - Make PR
 
+## Options
+* `strictMode` - In strict mode `*_id` items in the responses are numeric IDs. Default is *false* in which case expanded
+ objects are returned. Strict mode is recommended and is likely to be the default in the future.
+* `oauth` - whether the API token is to be used as OAuth bearer token instead of classic API key (default is *false*). 
+When setting `oauth` to true your application code must take care of fetching, storing and refershing the tokens.
+
 # How to use
 With a pre-set API token:
 ```js

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ pipedrive.Deals.getAll({}, function(err, deals) {
 ### Supported objects
 
  * Activities
+ * ActivityFields
  * ActivityTypes
  * Authorizations
  * Currencies
@@ -63,6 +64,7 @@ pipedrive.Deals.getAll({}, function(err, deals) {
  * CompanySettings,
  * Deals
  * DealFields
+ * EmailThreads
  * Files
  * Filters
  * Goals
@@ -79,6 +81,7 @@ pipedrive.Deals.getAll({}, function(err, deals) {
  * SearchResults
  * Stages
  * Users
+ * userFields
  * Webhooks
 
 ### Supported operations for object collections

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This Pipedrive API client is distributed under the MIT licence.
 - Make PR
 
 ## Options
+* `strictMode` - In strict mode `*_id` items in the responses are numeric IDs. Default is *false* in which case expanded
+ objects are returned. Strict mode is recommended and is likely to be the default in the future.
 * `oauth` - whether the API token is to be used as OAuth bearer token instead of classic API key (default is *false*). 
 When setting `oauth` to true your application code must take care of fetching, storing and refershing the tokens.
 

--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -22,6 +22,7 @@
 
 		var defaults = {
 			strictMode: false,
+			oauth: false,
 		};
 
 		options = _.extend({}, defaults, options);

--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -22,8 +22,6 @@
 
 		var defaults = {
 			strictMode: false,
-			apiHost: null,
-			apiVersion: null
 		};
 
 		options = _.extend({}, defaults, options);

--- a/lib/apiUrl.js
+++ b/lib/apiUrl.js
@@ -11,7 +11,7 @@
 
 	module.exports = function apiUrl(path, options, tokenNeeded) {
 		var queryObj = {};
-		if(options.useAccessToken)
+		if(options.oauth)
 			return protocol + '://' + proxyHost + '/' + path;
 
 		if (tokenNeeded) {

--- a/lib/apiUrl.js
+++ b/lib/apiUrl.js
@@ -5,7 +5,6 @@
 		qs = require('qs'),
 		protocol = 'https',
 		host = process.env.PIPEDRIVE_API_HOST || 'api.pipedrive.com',
-		proxyHost = process.env.PIPEDRIVE_API_HOST || 'api-proxy.pipedrive.com',
 		version = process.env.PIPEDRIVE_API_VERSION || 'v1',
 		baseUri = protocol + '://' + host + '/' + version;
 

--- a/lib/apiUrl.js
+++ b/lib/apiUrl.js
@@ -11,10 +11,8 @@
 
 	module.exports = function apiUrl(path, options, tokenNeeded) {
 		var queryObj = {};
-		if(options.oauth)
-			return protocol + '://' + proxyHost + '/' + path;
 
-		if (tokenNeeded) {
+		if (!options.oauth && tokenNeeded) {
 			queryObj.api_token = options.apiToken;
 		}
 		if (options.strictMode === true) {

--- a/lib/restHandlers.js
+++ b/lib/restHandlers.js
@@ -16,7 +16,7 @@
 
 		this.resolveOptions = function (options) {
 			options = options || {};
-			if(this.options.useAccessToken) {
+			if(this.options.oauth) {
 				options.accessToken = this.options.apiToken;
 			}
 			return options;
@@ -90,7 +90,7 @@
 	// GET /items
 	RestHandlers.prototype.listItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.useAccessToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = object == 'authorizations' ? { multipart: false, data: paramsToSupply } : { query: qs.stringify(paramsToSupply) },
 			req = rest[object == 'authorizations' ? 'post' : 'get'](apiUrl(object, this.options, false), this.resolveOptions(dataObject));
 
@@ -104,7 +104,7 @@
 	// GET /items/find
 	RestHandlers.prototype.findItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.useAccessToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply) },
 			req = rest.get(apiUrl(object + '/find', this.options, false), this.resolveOptions(dataObject));
 
@@ -118,7 +118,7 @@
 	// GET /items/timeline
 	RestHandlers.prototype.timelineItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.useAccessToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply) },
 			req = rest.get(apiUrl(object + '/timeline', this.options, false), this.resolveOptions(dataObject));
 
@@ -132,7 +132,7 @@
 	// GET /searchResults/field
 	RestHandlers.prototype.searchFields = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.useAccessToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply) },
 			req = rest.get(apiUrl(object + '/field', this.options, false), this.resolveOptions(dataObject));
 
@@ -146,7 +146,7 @@
 	// GET /items/5
 	RestHandlers.prototype.getItem = function(object, id, callback, params) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.useAccessToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { json: true, query: qs.stringify(paramsToSupply) },
 			req = rest.get(apiUrl(object + '/' + id, this.options, false), this.resolveOptions(dataObject));
 


### PR DESCRIPTION
@roniger 
Thank you so much for contributing! I tweaked your changes a bit. If you approve I believe we can merge.

- Renamed the library option to `oauth` to be more explicit about what it's for. `useAccessToken` seemed to be a bit vague.
- Added documentation on what the new option does
- Removed api-proxy.pipedrive.com domain, as it's no longer required. Both API key and OAuth tokens work on main API domain.
- Changed `apiUrl` for strict mode to still work